### PR TITLE
Support for Android 2.2 (Froyo) and 2.3 (Gingerbread) when using standard instantiation strategy (ObjenesisStd).

### DIFF
--- a/main/src/org/objenesis/instantiator/android/Android23Instantiator.java
+++ b/main/src/org/objenesis/instantiator/android/Android23Instantiator.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2006-2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.objenesis.instantiator.android;
+
+import org.objenesis.ObjenesisException;
+import org.objenesis.instantiator.ObjectInstantiator;
+
+import java.io.ObjectInputStream;
+import java.lang.reflect.Method;
+
+/**
+ * Instantiator for Android <= 2.3 which creates objects without driving their constructors, using internal
+ * methods on the Dalvik implementation of {@link java.io.ObjectInputStream}.
+ *
+ * @author Piotr 'Qertoip' Włodarek
+ */
+public class Android23Instantiator implements ObjectInstantiator {
+   private final Class type;
+   private final Method newStaticMethod;
+
+   public Android23Instantiator(Class type) {
+      this.type = type;
+      newStaticMethod = getNewStaticMethod();
+   }
+
+   public Object newInstance() {
+      try {
+         return newStaticMethod.invoke(null, new Object[]{type, Object.class});
+      }
+      catch(Exception e) {
+         throw new ObjenesisException(e);
+      }
+   }
+
+   private static Method getNewStaticMethod() {
+      try {
+         Method newStaticMethod = ObjectInputStream.class.getDeclaredMethod(
+           "newInstance", new Class[]{Class.class, Class.class});
+         newStaticMethod.setAccessible(true);
+         return newStaticMethod;
+      }
+      catch(RuntimeException e) {
+         throw new ObjenesisException(e);
+      }
+      catch(NoSuchMethodException e) {
+         throw new ObjenesisException(e);
+      }
+   }
+
+}

--- a/main/src/org/objenesis/instantiator/android/Android30Instantiator.java
+++ b/main/src/org/objenesis/instantiator/android/Android30Instantiator.java
@@ -23,17 +23,17 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 /**
- * Instantiator for Android which creates objects without driving their constructors, using internal
+ * Instantiator for Android >= 3.0 which creates objects without driving their constructors, using internal
  * methods on the Dalvik implementation of {@link ObjectStreamClass}.
  * 
  * @author Ian Parkinson (Google Inc.)
  */
-public class AndroidInstantiator implements ObjectInstantiator {
+public class Android30Instantiator implements ObjectInstantiator {
    private final Class type;
    private final Method newInstanceMethod;
    private final Integer objectConstructorId;
 
-   public AndroidInstantiator(Class type) {
+   public Android30Instantiator(Class type) {
       this.type = type;
       newInstanceMethod = getNewInstanceMethod();
       objectConstructorId = findConstructorIdForJavaLangObjectConstructor();

--- a/main/src/org/objenesis/strategy/StdInstantiatorStrategy.java
+++ b/main/src/org/objenesis/strategy/StdInstantiatorStrategy.java
@@ -16,7 +16,8 @@
 package org.objenesis.strategy;
 
 import org.objenesis.instantiator.ObjectInstantiator;
-import org.objenesis.instantiator.android.AndroidInstantiator;
+import org.objenesis.instantiator.android.Android23Instantiator;
+import org.objenesis.instantiator.android.Android30Instantiator;
 import org.objenesis.instantiator.gcj.GCJInstantiator;
 import org.objenesis.instantiator.jrockit.JRockit131Instantiator;
 import org.objenesis.instantiator.jrockit.JRockitLegacyInstantiator;
@@ -76,7 +77,15 @@ public class StdInstantiatorStrategy extends BaseInstantiatorStrategy {
          }
       }
       else if(JVM_NAME.startsWith(DALVIK)) {
-         return new AndroidInstantiator(type);
+        // System property "java.vm.version" seems to be 1.4.0 for Android 2.3 and 1.5.0 for Android 3.0
+        // so we use it here to choose the relevant implementation.
+        if(VENDOR_VERSION.compareTo("1.5.0") < 0) {
+          // Android 2.3 Gingerbread and lower
+          return new Android23Instantiator(type);
+        } else {
+          // Android 3.0 Honeycomb and higher
+          return new Android30Instantiator(type);
+        }
       }
       else if(JVM_NAME.startsWith(GNU)) {
          return new GCJInstantiator(type);


### PR DESCRIPTION
Support for Android 2.2 (Froyo) and 2.3 (Gingerbread) when using standard instantiation strategy (ObjenesisStd).

Android 3.0 and above were already supported so this should make Objenesis work on all Android platforms since 2.2 up to at least 4.2.2.
