### PR TITLE
Add Maven Central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ You can find the website and user documentation at http://objenesis.org.
 Developer information
 =====================
 
-Travis status
+Project status
 -------------
 [![Build Status](https://travis-ci.org/easymock/objenesis.svg?branch=master)](https://travis-ci.org/easymock/objenesis)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.objenesis/objenesis/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.objenesis/objenesis)
 
 Environment setup
 -----------------


### PR DESCRIPTION
Add Maven Central badge which makes it easier to get (just after a click) a ready to copy-paste code snippet to put into Maven/Gradle/Sbt/other build configuration file.