### PR TITLE
Mention Spock framework on "Who is using Objenesis" web page

### DIFF
--- a/website/site/content/who.html
+++ b/website/site/content/who.html
@@ -31,6 +31,7 @@ of them below.
     <li><a href="http://easymock.org">EasyMock</a></li>
     <li><a href="http://site.mockito.org">Mockito</a></li>
     <li><a href="https://github.com/EsotericSoftware/kryo">Kryo</a></li>
+    <li><a href="http://spockframework.org">Spock</a></li>
 </ul>
 
 </body>


### PR DESCRIPTION
This PR is just a small addition to the web site.

The Spock BDD testing and mocking framework uses Objenesis in order to mock final classes. You can e.g. also [spy on Groovy `@Singleton`s](https://stackoverflow.com/a/49604928/1082681) without calling their constructors, which would otherwise lead to errors, making spy instantiation impossible.