### PR TITLE
Add Dependencies Manifest Entry

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -38,6 +38,7 @@
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
             <manifestEntries>
               <Automatic-Module-Name>org.objenesis</Automatic-Module-Name>
+              <Dependencies>jdk.unsupported</Dependencies>
             </manifestEntries>
           </archive>
         </configuration>


### PR DESCRIPTION
Add a dependencies manifest entry so that Objenesis can access
jdk.unsupported when deployed in WildFly.

Objenesis needs access to `sun.reflect.ReflectionFactory` located in the `jdk.unsupported` module. WildFly by default restricts applications from accessing the `jdk.unsupported` module ([WFCORE-4055](https://issues.redhat.com/browse/WFCORE-4055)). 

To give Objenesis access to the `jdk.unsupported` module users need to do either of the following:

* Add a [Dependencies](https://docs.wildfly.org/20/Developer_Guide.html#dependencies-manifest-entries) manifest entry to the application or module itself
* Use [jboss-deployment-structure.xml](https://docs.wildfly.org/20/Developer_Guide.html#jboss-deployment-structure-file)

Adding the `Dependencies` manifest header to Objenesis itself making things "just work"(tm) for Objenesis users on WildFly.